### PR TITLE
fix: remove mainHandler.post wrapper causing thread conflicts in Android bridges

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -59,14 +59,19 @@ android {
     dependencies {
         testImplementation("org.jetbrains.kotlin:kotlin-test")
         testImplementation("org.mockito:mockito-core:5.0.0")
+
+        // Native Android SDK used by the plugin
         api "ai.verisoul:android:0.4.61"
+
+        // Unit test dependencies for deadlock demonstration tests
+        testImplementation("junit:junit:4.13.2")
+        testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
+        testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
 
     }
 
     testOptions {
         unitTests.all {
-            useJUnitPlatform()
-
             testLogging {
                events "passed", "skipped", "failed", "standardOut", "standardError"
                outputs.upToDateWhen {false}

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,0 +1,2 @@
+android.useAndroidX=true
+android.enableJetifier=true

--- a/android/src/main/kotlin/ai/verisoul/verisoul_sdk/VerisoulSdk.kt
+++ b/android/src/main/kotlin/ai/verisoul/verisoul_sdk/VerisoulSdk.kt
@@ -7,8 +7,6 @@ import ai.verisoul.sdk.helpers.webview.VerisoulSessionCallback
 import ai.verisoul.verisoul_sdk.generated.FlutterError
 import ai.verisoul.verisoul_sdk.generated.VerisoulApiHostApi
 import android.content.Context
-import android.os.Handler
-import android.os.Looper
 import android.view.MotionEvent
 
 class VerisoulSdk(val context: Context) : VerisoulApiHostApi {
@@ -33,33 +31,37 @@ class VerisoulSdk(val context: Context) : VerisoulApiHostApi {
         2 to MotionEvent.ACTION_MOVE,
     )
 
-    private val mainHandler = Handler(Looper.getMainLooper())
-
     override fun configure(enviroment: Long, projectId: String, callback: (Result<Unit>) -> Unit) {
-        mainHandler.post {
-            try {
-                val logLevel = sdkLogLevels[enviroment.toInt()]
-                if (logLevel == null) {
-                    callback.invoke(Result.failure(FlutterError(
-                        ErrorCodes.INVALID_ENVIRONMENT,
-                        "Invalid environment: $enviroment",
-                        null
-                    )))
-                    return@post
-                }
-
-                Verisoul.init(context, logLevel, projectId)
-                callback.invoke(Result.success(Unit))
-
-            } catch (e: VerisoulException) {
-                callback.invoke(Result.failure(FlutterError(e.code, e.message, null)))
-            } catch (e: Exception) {
-                callback.invoke(Result.failure(FlutterError(
-                    ErrorCodes.UNKNOWN_ERROR,
-                    e.message ?: "Failed to configure Verisoul SDK",
-                    null
-                )))
+        try {
+            val logLevel = sdkLogLevels[enviroment.toInt()]
+            if (logLevel == null) {
+                callback.invoke(
+                    Result.failure(
+                        FlutterError(
+                            ErrorCodes.INVALID_ENVIRONMENT,
+                            "Invalid environment: $enviroment",
+                            null
+                        )
+                    )
+                )
+                return
             }
+
+            Verisoul.init(context, logLevel, projectId)
+            callback.invoke(Result.success(Unit))
+
+        } catch (e: VerisoulException) {
+            callback.invoke(Result.failure(FlutterError(e.code, e.message, null)))
+        } catch (e: Exception) {
+            callback.invoke(
+                Result.failure(
+                    FlutterError(
+                        ErrorCodes.UNKNOWN_ERROR,
+                        e.message ?: "Failed to configure Verisoul SDK",
+                        null
+                    )
+                )
+            )
         }
     }
 
@@ -81,59 +83,76 @@ class VerisoulSdk(val context: Context) : VerisoulApiHostApi {
     }
 
     override fun getSessionId(callback: (Result<String>) -> Unit) {
-        mainHandler.post {
-            try {
-                Verisoul.getSessionId(object : VerisoulSessionCallback {
-                    override fun onFailure(exception: Throwable) {
-                        if (exception is VerisoulException) {
-                            callback.invoke(Result.failure(FlutterError(
-                                exception.code,
-                                exception.message,
-                                null
-                            )))
-                        } else {
-                            callback.invoke(Result.failure(FlutterError(
-                                ErrorCodes.SESSION_UNAVAILABLE,
-                                exception.message ?: "Failed to retrieve session ID",
-                                null
-                            )))
-                        }
+        try {
+            Verisoul.getSessionId(object : VerisoulSessionCallback {
+                override fun onFailure(exception: Throwable) {
+                    if (exception is VerisoulException) {
+                        callback.invoke(
+                            Result.failure(
+                                FlutterError(
+                                    exception.code,
+                                    exception.message,
+                                    null
+                                )
+                            )
+                        )
+                    } else {
+                        callback.invoke(
+                            Result.failure(
+                                FlutterError(
+                                    ErrorCodes.SESSION_UNAVAILABLE,
+                                    exception.message ?: "Failed to retrieve session ID",
+                                    null
+                                )
+                            )
+                        )
                     }
+                }
 
-                    override fun onSuccess(sessionId: String) {
-                        callback.invoke(Result.success(sessionId))
-                    }
-                })
-            } catch (e: VerisoulException) {
-                callback.invoke(Result.failure(FlutterError(
-                    e.code,
-                    e.message,
-                    null
-                )))
-            } catch (e: Throwable) {
-                callback.invoke(Result.failure(FlutterError(
-                    ErrorCodes.SESSION_UNAVAILABLE,
-                    e.message ?: "Failed to retrieve session ID",
-                    null
-                )))
-            }
+
+                override fun onSuccess(sessionId: String) {
+                    callback.invoke(Result.success(sessionId))
+                }
+            })
+        } catch (e: VerisoulException) {
+            callback.invoke(
+                Result.failure(
+                    FlutterError(
+                        e.code,
+                        e.message,
+                        null
+                    )
+                )
+            )
+        } catch (e: Throwable) {
+            callback.invoke(
+                Result.failure(
+                    FlutterError(
+                        ErrorCodes.SESSION_UNAVAILABLE,
+                        e.message ?: "Failed to retrieve session ID",
+                        null
+                    )
+                )
+            )
         }
     }
 
     override fun reinitialize(callback: (Result<Unit>) -> Unit) {
-        mainHandler.post {
-            try {
-                Verisoul.reinitialize()
-                callback.invoke(Result.success(Unit))
-            } catch (e: VerisoulException) {
-                callback.invoke(Result.failure(FlutterError(e.code, e.message, null)))
-            } catch (e: Exception) {
-                callback.invoke(Result.failure(FlutterError(
-                    ErrorCodes.UNKNOWN_ERROR,
-                    e.message ?: "Failed to reinitialize Verisoul SDK",
-                    null
-                )))
-            }
+        try {
+            Verisoul.reinitialize()
+            callback.invoke(Result.success(Unit))
+        } catch (e: VerisoulException) {
+            callback.invoke(Result.failure(FlutterError(e.code, e.message, null)))
+        } catch (e: Exception) {
+            callback.invoke(
+                Result.failure(
+                    FlutterError(
+                        ErrorCodes.UNKNOWN_ERROR,
+                        e.message ?: "Failed to reinitialize Verisoul SDK",
+                        null
+                    )
+                )
+            )
         }
     }
 

--- a/android/src/test/kotlin/ai/verisoul/verisoul_sdk/ThreadingDeadlockUnitTest.kt
+++ b/android/src/test/kotlin/ai/verisoul/verisoul_sdk/ThreadingDeadlockUnitTest.kt
@@ -1,0 +1,277 @@
+package ai.verisoul.verisoul_sdk
+
+import kotlinx.coroutines.*
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Test
+import java.util.concurrent.*
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Unit tests demonstrating why wrapping SDK calls in a main thread dispatcher
+ * can cause deadlocks when the SDK internally uses coroutines.
+ * 
+ * These tests run on JVM without needing an Android device.
+ * 
+ * Run with: gradle test
+ */
+class ThreadingDeadlockUnitTest {
+
+    /**
+     * Simulated "main thread" using a single-threaded executor, just like
+     * the RN test. This mimics Android's main/UI thread behavior.
+     */
+    private val mainThreadExecutor: ExecutorService = Executors.newSingleThreadExecutor { r ->
+        Thread(r, "MockMainThread")
+    }
+    private val mainThreadDispatcher: CoroutineDispatcher = mainThreadExecutor.asCoroutineDispatcher()
+
+    interface Callback {
+        fun onSuccess(result: String)
+        fun onFailure(error: Exception)
+    }
+
+    /**
+     * Mock SDK that simulates Verisoul Android SDK v0.4.61+ behavior:
+     *  - Does work on IO/background thread
+     *  - Dispatches callback to a "main thread" dispatcher internally
+     */
+    inner class MockSdkWithInternalMainDispatch {
+        fun getSessionId(callback: Callback) {
+            // SDK launches coroutine on IO thread
+            CoroutineScope(Dispatchers.IO).launch {
+                // Simulate work
+                delay(50)
+
+                // SDK internally dispatches to main thread for callback
+                withContext(mainThreadDispatcher) {
+                    callback.onSuccess("session-12345")
+                }
+            }
+        }
+    }
+
+    /**
+     * TEST 1: Demonstrates the DEADLOCK scenario.
+     * 
+     * Pattern that causes deadlock:
+     * 1. Force SDK call to run on main thread (via executor.submit + blocking wait)
+     * 2. SDK does background work
+     * 3. SDK tries to dispatch callback to main thread
+     * 4. Main thread is BLOCKED waiting for result = DEADLOCK
+     */
+    @Test(timeout = 3000)
+    fun testDeadlock_whenMainThreadBlocksWaitingForMainThreadCallback() {
+        val sdk = MockSdkWithInternalMainDispatch()
+        val deadlockOccurred = AtomicBoolean(false)
+        val completed = AtomicBoolean(false)
+
+        val future = mainThreadExecutor.submit {
+            val resultLatch = CountDownLatch(1)
+            val result = AtomicReference<String>()
+
+            sdk.getSessionId(object : Callback {
+                override fun onSuccess(r: String) {
+                    result.set(r)
+                    resultLatch.countDown()
+                }
+
+                override fun onFailure(error: Exception) {
+                    resultLatch.countDown()
+                }
+            })
+
+            // PROBLEM: This blocks the main thread waiting for callback
+            // But callback needs main thread to execute = DEADLOCK
+            val success = resultLatch.await(1, TimeUnit.SECONDS)
+            if (!success) {
+                deadlockOccurred.set(true)
+            } else {
+                completed.set(true)
+            }
+        }
+
+        try {
+            future.get(2, TimeUnit.SECONDS)
+        } catch (e: TimeoutException) {
+            deadlockOccurred.set(true)
+        }
+
+        // The test should detect deadlock (timeout)
+        assertTrue(
+            "Deadlock should be detected - main thread blocked waiting for callback that needs main thread",
+            deadlockOccurred.get()
+        )
+    }
+
+    /**
+     * TEST 2: Demonstrates the CORRECT approach (no deadlock).
+     * 
+     * Pattern that works:
+     * 1. Call SDK directly (don't force onto main thread)
+     * 2. SDK does background work
+     * 3. SDK dispatches callback to main thread
+     * 4. Main thread is FREE to handle callback = SUCCESS
+     */
+    @Test(timeout = 3000)
+    fun testNoDeadlock_whenCallingDirectlyWithoutMainThreadWrapper() {
+        val sdk = MockSdkWithInternalMainDispatch()
+        val completed = AtomicBoolean(false)
+        val resultLatch = CountDownLatch(1)
+        val result = AtomicReference<String>()
+
+        // Call SDK directly WITHOUT wrapping in main thread executor
+        // Let the SDK manage its own threading
+        sdk.getSessionId(object : Callback {
+            override fun onSuccess(r: String) {
+                result.set(r)
+                completed.set(true)
+                resultLatch.countDown()
+            }
+            override fun onFailure(error: Exception) {
+                resultLatch.countDown()
+            }
+        })
+
+        // Wait for result - main thread is free to handle callback
+        val success = resultLatch.await(2, TimeUnit.SECONDS)
+
+        assertTrue("Should complete successfully without deadlock", success)
+        assertTrue("Callback should have been called", completed.get())
+        assertEquals("session-12345", result.get())
+    }
+
+    /**
+     * TEST 3: Demonstrates the EXACT deadlock pattern from the old code.
+     * 
+     * This simulates what happened with mainHandler.post:
+     * - Flutter calls getSessionId()
+     * - Old code wraps in mainHandler.post { ... }
+     * - SDK callback needs main thread
+     * - If anything blocks main thread = potential deadlock
+     */
+    @Test(timeout = 5000)
+    fun testOldPattern_mainHandlerPostCanCauseContention() {
+        val sdk = MockSdkWithInternalMainDispatch()
+        val results = ConcurrentLinkedQueue<Long>()
+        val latch = CountDownLatch(5)
+
+        // Simulate multiple rapid calls (like Flutter might do)
+        repeat(5) { i ->
+            val startTime = System.currentTimeMillis()
+            
+            // OLD PATTERN: mainHandler.post { sdk.call() }
+            mainThreadExecutor.execute {
+                sdk.getSessionId(object : Callback {
+                    override fun onSuccess(r: String) {
+                        results.add(System.currentTimeMillis() - startTime)
+                        latch.countDown()
+                    }
+                    override fun onFailure(error: Exception) {
+                        latch.countDown()
+                    }
+                })
+            }
+        }
+
+        val allCompleted = latch.await(4, TimeUnit.SECONDS)
+        
+        // With mainHandler.post, calls get serialized on main thread
+        // causing them to queue up and take longer
+        println("Old pattern results (ms): $results")
+        
+        assertTrue("All calls should eventually complete", allCompleted)
+        
+        // Check if there's significant delay due to main thread contention
+        if (results.isNotEmpty()) {
+            val maxTime = results.maxOrNull() ?: 0
+            println("Max completion time with old pattern: ${maxTime}ms")
+        }
+    }
+
+    /**
+     * TEST 4: Demonstrates the NEW pattern has better concurrency.
+     */
+    @Test(timeout = 5000)
+    fun testNewPattern_directCallsHaveBetterConcurrency() {
+        val sdk = MockSdkWithInternalMainDispatch()
+        val results = ConcurrentLinkedQueue<Long>()
+        val latch = CountDownLatch(5)
+
+        // Simulate multiple rapid calls
+        repeat(5) { i ->
+            val startTime = System.currentTimeMillis()
+            
+            // NEW PATTERN: Direct call without mainHandler.post
+            sdk.getSessionId(object : Callback {
+                override fun onSuccess(r: String) {
+                    results.add(System.currentTimeMillis() - startTime)
+                    latch.countDown()
+                }
+                override fun onFailure(error: Exception) {
+                    latch.countDown()
+                }
+            })
+        }
+
+        val allCompleted = latch.await(4, TimeUnit.SECONDS)
+        
+        println("New pattern results (ms): $results")
+        
+        assertTrue("All calls should complete", allCompleted)
+        
+        if (results.isNotEmpty()) {
+            val maxTime = results.maxOrNull() ?: 0
+            println("Max completion time with new pattern: ${maxTime}ms")
+            
+            // New pattern allows better concurrency since calls don't 
+            // get serialized on main thread
+        }
+    }
+
+    /**
+     * TEST 5: Classic deadlock demonstration with runBlocking.
+     * 
+     * This is the most common deadlock pattern:
+     * - Main thread runs blocking code
+     * - Blocking code waits for coroutine
+     * - Coroutine needs main thread to complete
+     */
+    @Test(timeout = 3000)
+    fun testClassicDeadlock_runBlockingOnMainThreadWaitingForMain() {
+        val deadlockDetected = AtomicBoolean(false)
+
+        val future = mainThreadExecutor.submit {
+            try {
+                // runBlocking on main thread...
+                runBlocking {
+                    withTimeout(1000) {
+                        // ...waiting for something that needs main thread
+                        withContext(mainThreadDispatcher) {
+                            "This will never execute - DEADLOCK"
+                        }
+                    }
+                }
+            } catch (e: TimeoutCancellationException) {
+                deadlockDetected.set(true)
+            }
+        }
+
+        try {
+            future.get(2, TimeUnit.SECONDS)
+        } catch (e: TimeoutException) {
+            deadlockDetected.set(true)
+        }
+
+        assertTrue(
+            "Classic deadlock: runBlocking on main thread waiting for main thread dispatch",
+            deadlockDetected.get()
+        )
+    }
+
+    @After
+    fun tearDown() {
+        mainThreadExecutor.shutdownNow()
+    }
+}

--- a/android/src/test/kotlin/ai/verisoul/verisoul_sdk/VerisoulSdkPluginTest.kt
+++ b/android/src/test/kotlin/ai/verisoul/verisoul_sdk/VerisoulSdkPluginTest.kt
@@ -1,9 +1,7 @@
 package ai.verisoul.verisoul_sdk
 
-import io.flutter.plugin.common.MethodCall
-import io.flutter.plugin.common.MethodChannel
 import kotlin.test.Test
-import org.mockito.Mockito
+import kotlin.test.assertNotNull
 
 /*
  * This demonstrates a simple unit test of the Kotlin portion of this plugin's implementation.
@@ -15,13 +13,9 @@ import org.mockito.Mockito
 
 internal class VerisoulSdkPluginTest {
   @Test
-  fun onMethodCall_getPlatformVersion_returnsExpectedValue() {
-    val plugin = VerisoulSdkPlugin()
-
-    val call = MethodCall("getPlatformVersion", null)
-    val mockResult: MethodChannel.Result = Mockito.mock(MethodChannel.Result::class.java)
-    plugin.onMethodCall(call, mockResult)
-
-    Mockito.verify(mockResult).success("Android " + android.os.Build.VERSION.RELEASE)
+  fun plugin_instantiates() {
+    // The plugin is Pigeon-based (no MethodChannel onMethodCall handler anymore).
+    // This is a minimal smoke test to ensure the class is present and constructible.
+    assertNotNull(VerisoulSdkPlugin())
   }
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -251,7 +251,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.4.60"
+    version: "0.4.61"
   vm_service:
     dependency: transitive
     description:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes main-thread Handler wrapping from Android bridge calls and adds unit tests illustrating deadlock patterns, with minor build/test config updates.
> 
> - **Android bridge**:
>   - Remove `Handler(Looper.getMainLooper()).post { ... }` usage in `VerisoulSdk.configure`, `getSessionId`, and `reinitialize`; call SDK directly with existing error handling.
> - **Testing**:
>   - Add `ThreadingDeadlockUnitTest` demonstrating deadlock scenarios and improved concurrency when not forcing main-thread dispatch.
>   - Simplify `VerisoulSdkPluginTest` to a constructor smoke test.
>   - Add test deps (`junit`, `kotlinx-coroutines-core/test`) and adjust `testOptions`.
> - **Build/Config**:
>   - Enable AndroidX/Jetifier in `android/gradle.properties`.
>   - Update example `verisoul_sdk` to `0.4.61`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b36547f3ee8843f3ce5dee5dc60a6137b2bee40. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->