### PR TITLE
Add SDK size to System Requirements in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ _To run the SDK a Verisoul Project ID is required._ Schedule a call [here](https
 - iOS 14.0 or higher
 - Android API level 24 (Android 7.0) or higher
 - For Web: Modern browsers with JavaScript enabled
+- SDK Size: ~120 KB (plus native iOS and Android SDK dependencies)
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- Adds SDK size (~120 KB + native deps) to the System Requirements section of the README

## Test plan
- [ ] Verify README renders correctly on GitHub

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change with no impact on runtime behavior or dependencies.
> 
> **Overview**
> Adds the SDK’s approximate size (and note about native iOS/Android dependencies) to the `README.md` **System Requirements** section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7e5756718a8fc46dd2f86527b8095e8d51a6669. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->