### PR TITLE
chore: bump native SDKs (android 0.4.69, ios 0.4.68)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -61,7 +61,7 @@ android {
         testImplementation("org.mockito:mockito-core:5.0.0")
 
         // Native Android SDK used by the plugin
-        api "ai.verisoul:android:0.4.66"
+        api "ai.verisoul:android:0.4.69"
 
         // Unit test dependencies for deadlock demonstration tests
         testImplementation("junit:junit:4.13.2")

--- a/ios/verisoul_sdk.podspec
+++ b/ios/verisoul_sdk.podspec
@@ -16,7 +16,7 @@ Verisoul helps businesses stop fake accounts and fraud
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
   s.platform = :ios, '14.0'
-  s.dependency 'VerisoulSDK', '0.4.65'
+  s.dependency 'VerisoulSDK', '0.4.68'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }


### PR DESCRIPTION
## Summary
- Bump pinned native Android SDK to `0.4.69` (`android/build.gradle`).
- Bump pinned native iOS SDK (`VerisoulSDK`) to `0.4.68` (`ios/verisoul_sdk.podspec`).

Picks up the env-specific WebView host routing + Android JS bridge validation fix.

## Test plan
- [x] Example on Android emulator (prod): Repeat 30/30 and Chaos 40/40, every returned session_id authenticates 200
- [x] Confirmed live WebView host `https://js.verisoul.ai/webview.html` via the wrapper

Made with [Cursor](https://cursor.com)