### PR TITLE
chore: release 0.4.67 (native cross-project session fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.67 - 2026-06-26
+* Update verisoul/native-android-sdk to version 0.4.70 (clear cached session on project/environment change)
+* Update verisoul/native-ios-sdk to version 0.4.69
+
 ## 0.4.66 - 2026-06-25
 * Update verisoul/native-ios-sdk to version 0.4.68
 * Update verisoul/native-android-sdk to version 0.4.69

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ dependencies:
     sdk: flutter
   #  ...
 
-  verisoul_sdk: 0.4.65
+  verisoul_sdk: 0.4.67
 ```
 
 ### Android Configuration

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -61,7 +61,7 @@ android {
         testImplementation("org.mockito:mockito-core:5.0.0")
 
         // Native Android SDK used by the plugin
-        api "ai.verisoul:android:0.4.69"
+        api "ai.verisoul:android:0.4.70"
 
         // Unit test dependencies for deadlock demonstration tests
         testImplementation("junit:junit:4.13.2")

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -251,7 +251,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.4.64"
+    version: "0.4.67"
   vm_service:
     dependency: transitive
     description:

--- a/ios/verisoul_sdk.podspec
+++ b/ios/verisoul_sdk.podspec
@@ -16,7 +16,7 @@ Verisoul helps businesses stop fake accounts and fraud
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
   s.platform = :ios, '14.0'
-  s.dependency 'VerisoulSDK', '0.4.68'
+  s.dependency 'VerisoulSDK', '0.4.69'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: verisoul_sdk
 description: "Verisoul helps businesses stop fake accounts and fraud"
-version: 0.4.66
+version: 0.4.67
 homepage: https://www.verisoul.ai/
 repository: https://github.com/verisoul/flutter-sdk
 


### PR DESCRIPTION
## Summary
- Bumps native pins to pick up the cross-project/environment stale session fix:
  - `ai.verisoul:android` 0.4.69 → **0.4.70**
  - `VerisoulSDK` (iOS) 0.4.68 → **0.4.69**
- Bumps wrapper version to **0.4.67**, updates README install pin + CHANGELOG.

## Test plan
- [x] Flutter Android example builds against `ai.verisoul:android:0.4.70` (resolves from Artifact Registry)
- [x] Flutter Android prod gate: 30/30 returned sessions authenticate 200, 0 non-200

Made with [Cursor](https://cursor.com)